### PR TITLE
link serd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["lilv", "lv2", "audio"]
 license = "MIT"
 name = "lilv"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 lilv-sys = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -8,4 +8,8 @@ fn main() {
         .atleast_version("0.24.2")
         .probe("lilv-0")
         .expect("lilv-0 could not be found with pkg_config.");
+    pkg_config::Config::new()
+        .atleast_version("0.30.0")
+        .probe("serd-0")
+        .expect("serd-0 could not be found with pkg_config.");
 }


### PR DESCRIPTION
Hey there, I was having issues with linking the serd-0 library while running `cargo test` locally. I am actually using the livi crate, but traced the linking issue back to this crate. Seems like this fixes the issue for me, but I'm not sure if this is the right way to do it.